### PR TITLE
rpm spec: rename upstream config files

### DIFF
--- a/webtop5.spec
+++ b/webtop5.spec
@@ -34,6 +34,8 @@ mkdir -p root/usr/share/webtop/sql
 tar xvzf %{SOURCE2} -C root/usr/share/webtop/sql
 patch -d root/usr/share/webtop/sql -p1 < %{PATCH0}
 unzip %{SOURCE1} -d root/var/lib/tomcats/webtop/webapps/webtop
+mv root/var/lib/tomcats/webtop/webapps/webtop/META-INF/data-sources.xml root/var/lib/tomcats/webtop/webapps/webtop/META-INF/data-sources.xml.example
+mv root/var/lib/tomcats/webtop/webapps/webtop/WEB-INF/classes/logback.xml root/var/lib/tomcats/webtop/webapps/webtop/WEB-INF/classes/logback.xml.example
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
Add suffix `.example` to files:

* `/var/lib/tomcats/webtop/webapps/webtop/META-INF/data-sources.xml`
* `/var/lib/tomcats/webtop/webapps/webtop/WEB-INF/classes/logback.xml`

That prevent overwriting of customization made by users or others
packages (, eg. `nethserver-webtop5`)